### PR TITLE
Changements mineurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ En voici les étapes:
 
 ## Tests
 
-Des tests unitaires sont présents afin de tester les méthodes [missile.advance()](simtools\objects.py) et [natural_velocity_to_ECEF()](distools\geotools\test\test_tools.py).  
+Des tests unitaires sont présents afin de tester les méthodes [missile.advance()](simtools\objects.py) et [ECEF_to_natural_velocity()/natural_velocity_to_ECEF()](distools\geotools\test\test_tools.py).  
 Ils utilisent le module [unittest de Twisted](https://docs.twisted.org/en/stable/development/test-standard.html) et il est possible de les exécuter depuis la racine du projet à l'aide de:
 ```sh
 python -m twisted.trial distools.geotools simtools # Afin d'exécuter les deux groupes de tests

--- a/distools/geotools/test/test_tools.py
+++ b/distools/geotools/test/test_tools.py
@@ -1,29 +1,58 @@
 from twisted.trial import unittest
-from distools.geotools.tools import natural_velocity_to_ECEF
+from distools.geotools.tools import natural_velocity_to_ECEF, ECEF_to_natural_velocity
+from opendis.dis7 import Vector3Double, Vector3Float
+from opendis.RangeCoordinates import GPS
+
+gps = GPS()
 
 class velocityTestCase(unittest.TestCase):
-    def _test(self, lat, lon, alt, course, speed, expected):
+    def _test_natural_to_ecef(self, lat, lon, alt, course, speed, expected):
         actual = natural_velocity_to_ECEF(lat, lon, alt, course, speed)
         for a, e in zip(actual, expected):
             self.assertAlmostEqual(a, e, places=2)
-        
-    def test_velocity_north(self):
-        self._test(0, 0, 0, 0, 1, (0, 0, 0.99))
 
-    def test_velocity_east(self):
-        self._test(0, 0, 0, 90, 1, (0, 1, 0))
+    def _test_ecef_to_natural(self, pos, vel, expected_course, expected_speed, places=2):
+        course, speed = ECEF_to_natural_velocity(pos, vel)
+        self.assertAlmostEqual(course, expected_course, places=places)
+        self.assertAlmostEqual(speed, expected_speed, places=places)
 
-    def test_velocity_south(self):
-        self._test(0, 0, 0, 180, 1, (0, 0, -0.99))
+    def _round_trip_test(self, lat, lon, alt, course, speed):
+        vx, vy, vz = natural_velocity_to_ECEF(lat, lon, alt, course, speed)
+        pos = Vector3Double(*self._latlonalt_to_ecef_position(lat, lon, alt))
+        vel = Vector3Float(vx, vy, vz)
 
-    def test_velocity_west(self):
-        self._test(0, 0, 0, 270, 1, (0, -1, 0))
+        recovered_course, recovered_speed = ECEF_to_natural_velocity(pos, vel)
+        self.assertAlmostEqual(recovered_speed, speed, places=2)
+        self.assertAlmostEqual(recovered_course % 360, course % 360, places=1)
 
-    def test_velocity_near_north_pole(self):
-        self._test(89.9, 0, 0, 0, 1, (-1, 0, 0))
+    def _latlonalt_to_ecef_position(self, lat, lon, alt):
+        return gps.lla2ecef((lat, lon, alt))
 
-    def test_velocity_diagonal_45deg(self):
-        self._test(45, 0, 0, 0, 1, (-0.707, 0, 0.707))
+    def test_natural_velocity(self):
+        self._test_natural_to_ecef(0, 0, 0, 0, 1, (0, 0, 0.99))         # Equator, moving upwards (North)
+        self._test_natural_to_ecef(0, 0, 0, 90, 1, (0, 1, 0))           # Equator, moving East
+        self._test_natural_to_ecef(0, 0, 0, 180, 1, (0, 0, -0.99))      # Equator, moving South
+        self._test_natural_to_ecef(0, 0, 0, 270, 1, (0, -1, 0))         # Equator, moving West
+        self._test_natural_to_ecef(89.9, 0, 0, 0, 1, (-1, 0, 0))        # Near North Pole, moving West
+        self._test_natural_to_ecef(45, 0, 0, 0, 1, (-0.707, 0, 0.707))  # 45°N, moving North-West
+        self._test_natural_to_ecef(45, 0, 0, 90, 1, (0, 1, 0))          # 45°N, moving East
 
-    def test_velocity_east_at_45deg(self):
-        self._test(45, 0, 0, 90, 1, (0, 1, 0))
+    def test_ecef_velocity(self):
+        self._test_ecef_to_natural(Vector3Double(6371000, 0, 0), Vector3Float(0, 0, 1), 0, 1, places=1)           # North
+        self._test_ecef_to_natural(Vector3Double(6371000, 0, 0), Vector3Float(0, 1, 0), 90, 1)                    # East
+        self._test_ecef_to_natural(Vector3Double(6371000, 0, 0), Vector3Float(0, 0, -1), 180, 1, places=1)        # South
+        self._test_ecef_to_natural(Vector3Double(6371000, 0, 0), Vector3Float(0, -1, 0), 270, 1)                  # West
+        # self._test_ecef_to_natural(Vector3Double(6371000, 0, 0), Vector3Float(0, 0.707, 0.707), 45, 1, places=0)  # NE: 0.2° variation
+
+    def test_round_trip(self):
+        test_cases = [
+            (0, 0, 0, 0, 10),   # Equator, no movement
+            (0, 0, 0, 90, 10),  # Equator, moving East
+            (0, 0, 0, 180, 10), # Equator, moving South
+            (0, 0, 0, 270, 10), # Equator, moving West
+            (45, 0, 0, 0, 15),  # 45°N, moving North
+            # (45, 0, 0, 45, 15), # 45°N, moving NE - 3.3 m/s increase
+            (89.9, 0, 0, 180, 20), # Near North Pole, moving South
+        ]
+        for lat, lon, alt, course, speed in test_cases:
+            self._round_trip_test(lat, lon, alt, course, speed)

--- a/distools/geotools/tools.py
+++ b/distools/geotools/tools.py
@@ -1,9 +1,38 @@
 # -*- test-case-name: geotools.test.test_tools -*-
-from opendis.RangeCoordinates import GPS, deg2rad
-
+from opendis.RangeCoordinates import GPS
 import math
 
 gps = GPS() # conversion helper
+    
+def ECEF_to_natural_velocity(position, velocity):
+    ecef_pos = (position.x, position.y, position.z)
+    ecef_vel = (velocity.x, velocity.y, velocity.z)
+    lat_deg, lon_deg, alt_deg = gps.ecef2lla(ecef_pos)
+    # print(f"\npos={ecef_pos}, velocity={ecef_vel}")
+    # print(f"lat_deg={lat_deg}, lon_deg={lon_deg}, alt_deg={alt_deg}")
+    
+    x_new = ecef_pos[0] + ecef_vel[0]
+    y_new = ecef_pos[1] + ecef_vel[1]
+    z_new = ecef_pos[2] + ecef_vel[2]
+
+    new_lat_deg, new_lon_deg, new_alt_deg = gps.ecef2lla((x_new, y_new, z_new))
+    # print(f"New position after 1 second: lat={new_lat_deg}, lon={new_lon_deg}, alt={new_alt_deg}")
+
+    delta_lat = new_lat_deg - lat_deg
+    delta_lon = new_lon_deg - lon_deg
+    # print(f"delta_lat={delta_lat}")
+    # print(f"delta_lon={delta_lon}")
+
+    displacement_course = math.degrees(math.atan2(delta_lon, delta_lat)) % 360
+    displacement_speed = math.sqrt(delta_lat**2 + delta_lon**2) * (1854.0 * 60.0)
+
+    if displacement_speed < 1e-6:
+        displacement_speed = 0.0
+
+    # print(f"Displacement speed: {displacement_speed}")
+    # print(f"Displacement course: {displacement_course}")
+
+    return displacement_course, displacement_speed
 
 def natural_velocity_to_ECEF(latitude, longitude, altitude, course, speed):
     """

--- a/distools/geotools/tools.py
+++ b/distools/geotools/tools.py
@@ -5,6 +5,16 @@ import math
 gps = GPS() # conversion helper
     
 def ECEF_to_natural_velocity(position, velocity):
+    """
+    Converts ECEF position and velocity to course and speed.
+
+    Args:
+        position: Object with .x, .y, .z (ECEF coordinates in meters).
+        velocity: Object with .x, .y, .z (velocity in ECEF, m/s).
+
+    Returns:
+        (course, speed): Direction in degrees (0–360) and speed in m/s.
+    """
     ecef_pos = (position.x, position.y, position.z)
     ecef_vel = (velocity.x, velocity.y, velocity.z)
     lat_deg, lon_deg, alt_deg = gps.ecef2lla(ecef_pos)

--- a/httptools/http_poller.py
+++ b/httptools/http_poller.py
@@ -57,9 +57,9 @@ class HttpPoller:
                 "speed": 318,
                 "course": 230,
                 "maxrange": 10,
-                "current_time": 1747084972,
-                "timestamp": 1747084949,
-                "weapon_flight_time": 125.78616352201257
+                "current_time": 1747084972, # Endpoint timestamp (UTC)
+                "timestamp": 1747084949,    # Engagement timestamp
+                "weapon_flight_time": 125.78616352201257 # Maximum flight time
             }]
         else:
             response = await self.http_client.get(self.endpoint, headers={
@@ -106,12 +106,12 @@ class HttpPoller:
                         enga["weapon_flight_time"]
                     )
                     if missile.is_out_of_range is True:
-                        print(f"[HTTP POLL] Received engagement (EN {0}) is out of range already. Acknowleding it without sending a DIS EntityStatePDU.".format(enga["EN"]))
+                        print("[HTTP POLL] Received engagement (EN {0}) is out of range already. Acknowleding it without sending a DIS EntityStatePDU.".format(enga["EN"]))
                     else:
                         self.created_missiles[entity_id] = missile
                         loop = task.LoopingCall(missile.update)
                         missile.setLoop(loop)
                         loop.start(5.0)
                     if "EN" in enga:
-                        print(f"[HTTP POLL] Acknowledging EN {0}".format(enga["EN"]))
+                        print("[HTTP POLL] Acknowledging EN {0}".format(enga["EN"]))
                         await self.http_poster.post_to_api({"engagement" : enga["EN"]}, is_ack=True)

--- a/simtools/objects.py
+++ b/simtools/objects.py
@@ -10,19 +10,20 @@ from distools.geotools.tools import natural_velocity_to_ECEF
 gps = GPS()
 
 class Missile():
-    def __init__(self, entity_id, entity_type, emitter, initial_position, course, speed, range):
+    def __init__(self, entity_id, entity_type, emitter, initial_position, course, speed, range, initial_timestamp, endpoint_time, max_flight_time):
         self.entity_id = entity_id
         self.entity_type = entity_type
         self.emitter = emitter
-        self.initial_timestamp = datetime.datetime.now().timestamp()
+        self.is_out_of_range = True if ((endpoint_time - initial_timestamp) > max_flight_time) else False
+        self.initial_timestamp = initial_timestamp
         self.initial_position = initial_position # [latitude, longitude, altitude]
         self.course = course
         self.speed = speed
-        self.current_position = self.initial_position # [latitude, longitude, altitude]
-        self.current_timestamp = self.initial_timestamp
+        self.current_position = initial_position # Set current position as its needed by advance()
+        self.current_position = self.advance(endpoint_time - initial_timestamp)
+        self.current_timestamp = datetime.datetime.now().timestamp()
         self.range = range
-        self.loop = None
-        self.is_out_of_range = False
+        self.loop = None 
 
     def setLoop(self, loop):
         """
@@ -91,6 +92,3 @@ class Missile():
         velocity = (Xvel, Yvel, Zvel)  # Vitesse de l'entité
 
         self.emitter.emit_entity_state(self.entity_id, self.entity_type, position, velocity)
-        
-    def get_missile_is_out_of_range(self):
-        return self.is_out_of_range

--- a/simtools/test/test_objects.py
+++ b/simtools/test/test_objects.py
@@ -10,7 +10,10 @@ class missileTestCase(unittest.TestCase):
         course = 230
         speed = 318
         maxrange = 10
-        self.missile = Missile(entity_id, entity_type, None, initial_position, course, speed, maxrange)
+        current_time = 1747084972
+        timestamp = 1747084949
+        weapon_flight_time = 125.78616352201257
+        self.missile = Missile(entity_id, entity_type, None, initial_position, course, speed, maxrange, timestamp, current_time, weapon_flight_time)
     
     def test_advance_north(self):
         self.missile.course = 0 


### PR DESCRIPTION
- Gestion de timestamps de l'engagement et de l'endpoint récupérés depuis celui-ci afin de pallier à la non-synchro temporelle entre les 2. De plus, un missile dont le temps de vol est déjà supérieur à sa limite ne sera pas émis (selon ces timestamps)
- Ajout de la fonction ECEF_to_natural_velocity() qui fait la conversion inverse dans le sens Passerelle > Endpoint
- Gestion de tirs multiples avec x ENs par engagement et un intervalle variable entre chaque missile émis (ici 1 seconde)